### PR TITLE
TINKERPOP-2569 simple fix

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Prevented XML External Entity (XXE) style attacks via `GraphMLReader` by disabling DTD and external entities by default.
 * Fixed a `NullPointerException` that could occur during a failed `Connection` initialization due to uninstantiated `AtomicInteger`.
+* Fixed issue with reconnecting to a live host that was initially dead by adding a flag to indicate when no live host is available and client should reinitialize.
 
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: July 19, 2021)

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -1877,4 +1877,71 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
         assertEquals(100, result1.get().one().getInt());
     }
+
+    /**
+     * Client created on an initially dead host should fail initially, and recover after the dead host has restarted
+     * @param testClusterClient - boolean flag set to test clustered client if true and sessioned client if false
+     * @throws Exception
+     */
+    public void testShouldFailOnInitiallyDeadHost(final boolean testClusterClient) throws Exception {
+        logger.info("Stopping server.");
+        this.stopServer();
+
+        final Cluster cluster = TestClientFactory.build().create();
+        final Client client = testClusterClient? cluster.connect() : cluster.connect("sessionClient");
+
+        try {
+            // try to re-issue a request now that the server is down
+            logger.info("Verifying driver cannot connect to server.");
+            client.submit("g").all().get(500, TimeUnit.MILLISECONDS);
+            fail("Should throw an exception.");
+        } catch (RuntimeException re) {
+            // Client would have no active connections to the host, hence it would encounter a timeout
+            // trying to find an alive connection to the host.
+
+            // This is actually an instance of RuntimeException() wrapped around a NoHostAvailableException() thrown
+            // inside submitAsync() when there is no live host, and it is NOT the NoHostAvailableException()
+            // at client initiation. Client initiation will only throw NoHostAvailableException() if no host was added,
+            // but it will not check if the host is live or dead. That is checked at submitAsync().
+            assertThat(re.getCause(), instanceOf(RuntimeException.class));
+
+            //
+            // should recover when the server comes back
+            //
+
+            // restart server
+            logger.info("Restarting server.");
+            this.startServer();
+
+            // try a bunch of times to reconnect. on slower systems this may simply take longer...looking at you travis
+            for (int ix = 1; ix < 11; ix++) {
+                // the retry interval is 1 second, wait a bit longer
+                TimeUnit.MILLISECONDS.sleep(1250);
+
+                try {
+                    logger.info(String.format("Connection driver to server - attempt # %s. ", 1 + ix));
+                    final List<Result> results = client.submit("1+1").all().get(3000, TimeUnit.MILLISECONDS);
+                    assertEquals(1, results.size());
+                    assertEquals(2, results.get(0).getInt());
+                    logger.info("Connection successful.");
+                    break;
+                } catch (Exception ex) {
+                    if (ix == 10)
+                        fail("Should have eventually succeeded");
+                }
+            }
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void shouldFailOnInitiallyDeadHostForClusterClient() throws Exception {
+        testShouldFailOnInitiallyDeadHost(true);
+    }
+
+    @Test
+    public void shouldFailOnInitiallyDeadHostForSessionClient() throws Exception {
+        testShouldFailOnInitiallyDeadHost(false);
+    }
 }


### PR DESCRIPTION
Successfully builds with `mvn clean install && mvn verify -pl gremlin-server,gremlin-console -DskipIntegrationTests=false`

A very simple fix that adds a flag to indicate when there is no host, so we can re-init() the client. My only concern is on line `534` in `Client.java`, where I am not sure if that is the appropriate place to set the flag. Please comment.