### PR TITLE
Tinkerpop 2569 fixes with new approach

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Prevented XML External Entity (XXE) style attacks via `GraphMLReader` by disabling DTD and external entities by default.
 * Fixed a `NullPointerException` that could occur during a failed `Connection` initialization due to uninstantiated `AtomicInteger`.
+* Minor changes to the initialization of Java driver `Cluster` and `Client` such that hosts are marked as available only after successfully initializing connection pools.
 
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: July 19, 2021)

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -114,7 +114,8 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
         } catch (final FileNotFoundException ignored) {
             throw new RemoteException("The 'connect' option must be accompanied by a valid configuration file");
         } catch (NoHostAvailableException nhae) {
-            return "Host was not available - the Gremlin Console is making attempts to reconnect in accordance with the 'reconnectInterval' driver configuration but you may wish to close this remote and investigate the problem directly";
+            return "Host was not available - the Gremlin Console is making attempts to reconnect in accordance with the 'reconnectInterval' " +
+                    "driver configuration but you may wish to close this remote and investigate the problem directly";
         } catch (final Exception ex) {
             throw new RemoteException("Error during 'connect' - " + ex.getMessage(), ex);
         }

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -113,9 +113,6 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
             return String.format("Configured %s", this.currentCluster) + getSessionStringSegment();
         } catch (final FileNotFoundException ignored) {
             throw new RemoteException("The 'connect' option must be accompanied by a valid configuration file");
-        } catch (NoHostAvailableException nhae) {
-            return "Host was not available - the Gremlin Console is making attempts to reconnect in accordance with the 'reconnectInterval' " +
-                    "driver configuration but you may wish to close this remote and investigate the problem directly";
         } catch (final Exception ex) {
             throw new RemoteException("Error during 'connect' - " + ex.getMessage(), ex);
         }

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.driver.RequestOptions;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
+import org.apache.tinkerpop.gremlin.driver.exception.NoHostAvailableException;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.jsr223.console.GremlinShellEnvironment;
@@ -112,6 +113,8 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
             return String.format("Configured %s", this.currentCluster) + getSessionStringSegment();
         } catch (final FileNotFoundException ignored) {
             throw new RemoteException("The 'connect' option must be accompanied by a valid configuration file");
+        } catch (NoHostAvailableException nhae) {
+            return "Host was not available - the Gremlin Console is making attempts to reconnect in accordance with the 'reconnectInterval' driver configuration but you may wish to close this remote and investigate the problem directly";
         } catch (final Exception ex) {
             throw new RemoteException("Error during 'connect' - " + ex.getMessage(), ex);
         }

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -25,7 +25,6 @@ import org.apache.tinkerpop.gremlin.driver.RequestOptions;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
-import org.apache.tinkerpop.gremlin.driver.exception.NoHostAvailableException;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.jsr223.console.GremlinShellEnvironment;

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
@@ -30,9 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -126,11 +124,9 @@ public class DriverRemoteAcceptorTest {
         acceptor.configure(Arrays.asList("timeout", "-1"));
     }
 
-    @Test
-    public void shouldConnect() throws Exception {
-        // there is no gremlin server running for this test, but gremlin-driver lazily connects so this should
-        // be ok to just validate that a connection is created
-        assertThat(acceptor.connect(Arrays.asList(Storage.toPath(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp")))).toString(),
-                startsWith("Host was not available "));
+    @Test(expected = RemoteException.class)
+    public void shouldNotConnectWhenNoHostIsAvailable() throws Exception {
+        // there is no gremlin server running for this test, so this remote should throw due to NoHostAvailable exception thrown by the driver
+        acceptor.connect(Arrays.asList(Storage.toPath(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp"))));
     }
 }

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
@@ -131,6 +131,6 @@ public class DriverRemoteAcceptorTest {
         // there is no gremlin server running for this test, but gremlin-driver lazily connects so this should
         // be ok to just validate that a connection is created
         assertThat(acceptor.connect(Arrays.asList(Storage.toPath(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp")))).toString(),
-                   startsWith("Configured "));
+                startsWith("Host was not available "));
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -527,8 +527,8 @@ public abstract class Client {
 
             try {
                 CompletableFuture.allOf(cluster.allHosts().stream()
-                                .map(host -> CompletableFuture.runAsync(() -> initializeConnectionSetupForHost.accept(host), hostExecutor))
-                                .toArray(CompletableFuture[]::new))
+                        .map(host -> CompletableFuture.runAsync(() -> initializeConnectionSetupForHost.accept(host), hostExecutor))
+                        .toArray(CompletableFuture[]::new))
                         .join();
             } catch (CompletionException ex) {
                 logger.error("", (ex.getCause() == null) ? ex : ex.getCause());
@@ -578,7 +578,6 @@ public abstract class Client {
 
                 // added a new host to the cluster so let the load-balancer know
                 ClusteredClient.this.cluster.loadBalancingStrategy().onNew(host);
-
             } catch (RuntimeException ex) {
                 throw new RuntimeException(String.format("Could not initialize client for %s.", host), ex);
             }
@@ -591,8 +590,8 @@ public abstract class Client {
             // we will start the re-initialization attempt for each of the unavailable hosts through makeUnavailable()
             try {
                 CompletableFuture.allOf(unavailableHosts.stream()
-                                .map(host -> CompletableFuture.runAsync(() -> host.makeUnavailable(this::tryReInitializeHost), hostExecutor))
-                                .toArray(CompletableFuture[]::new))
+                        .map(host -> CompletableFuture.runAsync(() -> host.makeUnavailable(this::tryReInitializeHost), hostExecutor))
+                        .toArray(CompletableFuture[]::new))
                         .join();
             } catch (CompletionException ex) {
                 logger.error("", (ex.getCause() == null) ? ex : ex.getCause());
@@ -606,7 +605,7 @@ public abstract class Client {
          * as part of a schedule in {@link Host} to periodically try to re-initialize.
          */
         public boolean tryReInitializeHost(final Host host) {
-            logger.warn("Trying to re-initiate host connection pool on {}", host);
+            logger.debug("Trying to re-initiate host connection pool on {}", host);
 
             try {
                 // hosts that don't initialize connection pools will come up as a dead host
@@ -619,7 +618,7 @@ public abstract class Client {
                 host.makeAvailable();
                 return true;
             } catch (Exception ex) {
-                logger.warn("Failed re-initialization attempt on {}", host, ex);
+                logger.debug("Failed re-initialization attempt on {}", host, ex);
                 return false;
             }
         }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -588,7 +588,7 @@ public abstract class Client {
             final BasicThreadFactory threadFactory = new BasicThreadFactory.Builder().namingPattern("gremlin-driver-initializer").build();
             final ExecutorService hostExecutor = Executors.newSingleThreadExecutor(threadFactory);
 
-            // we will start the re-initiation attempt for each of the unavailable hosts through makeUnavailable()
+            // we will start the re-initialization attempt for each of the unavailable hosts through makeUnavailable()
             try {
                 CompletableFuture.allOf(unavailableHosts.stream()
                                 .map(host -> CompletableFuture.runAsync(() -> host.makeUnavailable(this::tryReInitializeHost), hostExecutor))
@@ -619,7 +619,7 @@ public abstract class Client {
                 host.makeAvailable();
                 return true;
             } catch (Exception ex) {
-                logger.warn("Failed re-initiation attempt on {}", host, ex);
+                logger.warn("Failed re-initialization attempt on {}", host, ex);
                 return false;
             }
         }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -591,7 +591,7 @@ public abstract class Client {
             // we will start the re-initiation attempt for each of the unavailable hosts through makeUnavailable()
             try {
                 CompletableFuture.allOf(unavailableHosts.stream()
-                                .map(host -> CompletableFuture.runAsync(() -> host.makeUnavailable(this::tryReInitiateHost), hostExecutor))
+                                .map(host -> CompletableFuture.runAsync(() -> host.makeUnavailable(this::tryReInitializeHost), hostExecutor))
                                 .toArray(CompletableFuture[]::new))
                         .join();
             } catch (CompletionException ex) {
@@ -602,10 +602,10 @@ public abstract class Client {
         }
 
         /**
-         * Attempt to re-initiate to the {@link Host} that was previously marked as unavailable.  This method gets called
-         * as part of a schedule in {@link Host} to periodically try to create working re-initiations.
+         * Attempt to re-initialize the {@link Host} that was previously marked as unavailable.  This method gets called
+         * as part of a schedule in {@link Host} to periodically try to re-initialize.
          */
-        public boolean tryReInitiateHost(final Host host) {
+        public boolean tryReInitializeHost(final Host host) {
             logger.warn("Trying to re-initiate host connection pool on {}", host);
 
             try {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -1283,8 +1283,6 @@ public final class Cluster {
 
             contactPoints.forEach(address -> {
                 final Host host = add(address);
-                if (host != null)
-                    host.makeAvailable();
             });
         }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -1898,7 +1898,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         } catch (RuntimeException re) {
             // Client would have no active connections to the host, hence it would encounter a timeout
             // trying to find an alive connection to the host.
-            Throwable foo = re.getCause();
             assertThat(re.getCause(), instanceOf(NoHostAvailableException.class));
 
             //

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -1924,10 +1924,10 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
                 } catch (Exception ex) {
                     if (ix == 10)
                         fail("Should have eventually succeeded");
-                } finally {
-                    cluster.close();
                 }
             }
+        } finally {
+            cluster.close();
         }
     }
 


### PR DESCRIPTION
Fixed bug with new approach based on Divij's comments, where NoHostAvailableException is thrown when no hosts are live at client initialization, and if there are multiple hosts, dead hosts, if any, are being re-tried in the background.